### PR TITLE
Add CODEOWNERS assigning @sebdalgarno

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @sebdalgarno


### PR DESCRIPTION
Adds `.github/CODEOWNERS` assigning @sebdalgarno as the code owner for all files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)