### PR TITLE
chore: Format with air

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -18,3 +18,5 @@
 ^data-raw$
 ^doc$
 ^Meta$
+^[.]?air[.]toml$
+^\.vscode$

--- a/R/collection-properties.R
+++ b/R/collection-properties.R
@@ -9,7 +9,9 @@
 #' @examples
 #' fwa_collection_properties("whse_basemapping.fwa_stream_networks_sp")
 fwa_collection_properties <- function(
-    collection_id, nocache = getOption("fwa.nocache", FALSE)) {
+  collection_id,
+  nocache = getOption("fwa.nocache", FALSE)
+) {
   chk_flag(nocache)
   pgfeatureserv::pgf_collection_properties(
     collection_id = collection_id,

--- a/R/collection.R
+++ b/R/collection.R
@@ -3,19 +3,29 @@
 #' \lifecycle{soft-deprecated}
 #'
 #' @export
-fwa_collection <- function(collection_id,
-                           filter = NULL,
-                           limit = 10000,
-                           bbox = NULL,
-                           properties = NULL,
-                           transform = NULL,
-                           epsg = 4326,
-                           nocache = getOption("fwa.nocache", FALSE)) {
-  lifecycle::deprecate_soft("0.1.1", "fwa_collection()", "fwa_query_collection()")
-  fwa_query_collection(collection_id,
-    filter = filter, limit = limit,
+fwa_collection <- function(
+  collection_id,
+  filter = NULL,
+  limit = 10000,
+  bbox = NULL,
+  properties = NULL,
+  transform = NULL,
+  epsg = 4326,
+  nocache = getOption("fwa.nocache", FALSE)
+) {
+  lifecycle::deprecate_soft(
+    "0.1.1",
+    "fwa_collection()",
+    "fwa_query_collection()"
+  )
+  fwa_query_collection(
+    collection_id,
+    filter = filter,
+    limit = limit,
     bbox = bbox,
-    properties = properties, transform = transform,
-    epsg = epsg, nocache = nocache
+    properties = properties,
+    transform = transform,
+    epsg = epsg,
+    nocache = nocache
   )
 }

--- a/R/hydroshed.R
+++ b/R/hydroshed.R
@@ -10,13 +10,16 @@
 #' @export
 #' @examples
 #' hydroshed(x = -132.26, y = 53.36)
-hydroshed <- function(x, y,
-                      srid = 4326,
-                      bbox = NULL,
-                      properties = NULL,
-                      transform = NULL,
-                      epsg = 4326,
-                      nocache = getOption("fwa.nocache", FALSE)) {
+hydroshed <- function(
+  x,
+  y,
+  srid = 4326,
+  bbox = NULL,
+  properties = NULL,
+  transform = NULL,
+  epsg = 4326,
+  nocache = getOption("fwa.nocache", FALSE)
+) {
   chk_number(x)
   chk_number(y)
   chk_whole_number(srid)

--- a/R/index-point.R
+++ b/R/index-point.R
@@ -11,15 +11,18 @@
 #' @export
 #' @examples
 #' fwa_index_point(x = -132.26, y = 53.36)
-fwa_index_point <- function(x, y,
-                            srid = 4326,
-                            tolerance = 5000,
-                            limit = 1,
-                            bbox = NULL,
-                            properties = NULL,
-                            transform = NULL,
-                            epsg = 4326,
-                            nocache = getOption("fwa.nocache", FALSE)) {
+fwa_index_point <- function(
+  x,
+  y,
+  srid = 4326,
+  tolerance = 5000,
+  limit = 1,
+  bbox = NULL,
+  properties = NULL,
+  transform = NULL,
+  epsg = 4326,
+  nocache = getOption("fwa.nocache", FALSE)
+) {
   chk_number(x)
   chk_number(y)
   chk_whole_number(srid)

--- a/R/internal.R
+++ b/R/internal.R
@@ -19,5 +19,17 @@ nocache_conversion <- function(nocache) {
 
 any_to_int <- function(data) {
   data |>
-    dplyr::mutate(dplyr::across(tidyselect::any_of(c("blue_line_key", "blue_line_key_50k", "gnis_id", "linear_feature_id", "watershed_group_id", "watershed_key", "watershed_key_50k", "hex_id")), as.integer))
+    dplyr::mutate(dplyr::across(
+      tidyselect::any_of(c(
+        "blue_line_key",
+        "blue_line_key_50k",
+        "gnis_id",
+        "linear_feature_id",
+        "watershed_group_id",
+        "watershed_key",
+        "watershed_key_50k",
+        "hex_id"
+      )),
+      as.integer
+    ))
 }

--- a/R/locate-along-interval.R
+++ b/R/locate-along-interval.R
@@ -9,15 +9,16 @@
 #' @examples
 #' fwa_locate_along_interval(356308001, interval_length = 10, start_measure = 0)
 fwa_locate_along_interval <- function(
-    blue_line_key,
-    interval_length = 100,
-    start_measure = 0,
-    end_measure = NULL,
-    bbox = NULL,
-    properties = NULL,
-    transform = NULL,
-    epsg = 4326,
-    nocache = getOption("fwa.nocache", FALSE)) {
+  blue_line_key,
+  interval_length = 100,
+  start_measure = 0,
+  end_measure = NULL,
+  bbox = NULL,
+  properties = NULL,
+  transform = NULL,
+  epsg = 4326,
+  nocache = getOption("fwa.nocache", FALSE)
+) {
   chk_whole_number(blue_line_key)
   chk_gt(blue_line_key)
   chk_whole_number(interval_length)
@@ -29,7 +30,9 @@ fwa_locate_along_interval <- function(
   chk_gt(epsg)
   chk_flag(nocache)
 
-  if (!is.null(end_measure)) chk_gt(end_measure, start_measure)
+  if (!is.null(end_measure)) {
+    chk_gt(end_measure, start_measure)
+  }
 
   if (!is.null(end_measure)) {
     lim <- ceiling((end_measure - start_measure) / interval_length)
@@ -37,7 +40,10 @@ fwa_locate_along_interval <- function(
       chk::abort_chk(
         "`limit` must be greater than ",
         "(`end_measure` - `start_measure`) / `interval_length` (",
-        lim, ") not ", 10000L, "."
+        lim,
+        ") not ",
+        10000L,
+        "."
       )
     }
   }
@@ -66,5 +72,8 @@ fwa_locate_along_interval <- function(
   )
 
   sf::st_transform(x, epsg) |>
-    dplyr::mutate(dplyr::across(tidyselect::all_of(c("downstream_route_measure", "index")), as.integer))
+    dplyr::mutate(dplyr::across(
+      tidyselect::all_of(c("downstream_route_measure", "index")),
+      as.integer
+    ))
 }

--- a/R/locate-along.R
+++ b/R/locate-along.R
@@ -9,13 +9,15 @@
 #' @export
 #' @examples
 #' fwa_locate_along(356308001, downstream_route_measure = 10000)
-fwa_locate_along <- function(blue_line_key,
-                             downstream_route_measure = 0,
-                             bbox = NULL,
-                             properties = NULL,
-                             transform = NULL,
-                             epsg = 4326,
-                             nocache = getOption("fwa.nocache", FALSE)) {
+fwa_locate_along <- function(
+  blue_line_key,
+  downstream_route_measure = 0,
+  bbox = NULL,
+  properties = NULL,
+  transform = NULL,
+  epsg = 4326,
+  nocache = getOption("fwa.nocache", FALSE)
+) {
   chk_whole_number(blue_line_key)
   chk_gt(blue_line_key)
   chk_number(downstream_route_measure)

--- a/R/meta-collections.R
+++ b/R/meta-collections.R
@@ -6,6 +6,10 @@
 #'
 #' @export
 fwa_meta_collections <- function(nocache = getOption("fwa.nocache", FALSE)) {
-  lifecycle::deprecate_soft(" 0.1.1", "fwa_meta_collections()", "fwa_collections()")
+  lifecycle::deprecate_soft(
+    " 0.1.1",
+    "fwa_meta_collections()",
+    "fwa_collections()"
+  )
   fwa_collections(nocache = nocache)
 }

--- a/R/meta-properties.R
+++ b/R/meta-properties.R
@@ -5,7 +5,14 @@
 #' \lifecycle{soft-deprecated}
 #'
 #' @export
-fwa_meta_properties <- function(collection_id, nocache = getOption("fwa.nocache", FALSE)) {
-  lifecycle::deprecate_soft(" 0.1.1", "fwa_meta_properties()", "fwa_collection_properties()")
+fwa_meta_properties <- function(
+  collection_id,
+  nocache = getOption("fwa.nocache", FALSE)
+) {
+  lifecycle::deprecate_soft(
+    " 0.1.1",
+    "fwa_meta_properties()",
+    "fwa_collection_properties()"
+  )
   fwa_collection_properties(collection_id, nocache = nocache)
 }

--- a/R/query-collection.R
+++ b/R/query-collection.R
@@ -13,17 +13,19 @@
 #' collection_id <- "whse_basemapping.fwa_stream_networks_sp"
 #' filter <- list(gnis_name = "Sangan River")
 #' fwa_query_collection(collection_id, filter = filter)
-fwa_query_collection <- function(collection_id,
-                                 filter = NULL,
-                                 limit = 10000,
-                                 offset = 0,
-                                 bbox = NULL,
-                                 properties = NULL,
-                                 transform = NULL,
-                                 sortby = NULL,
-                                 groupby = NULL,
-                                 epsg = 4326,
-                                 nocache = getOption("fwa.nocache", FALSE)) {
+fwa_query_collection <- function(
+  collection_id,
+  filter = NULL,
+  limit = 10000,
+  offset = 0,
+  bbox = NULL,
+  properties = NULL,
+  transform = NULL,
+  sortby = NULL,
+  groupby = NULL,
+  epsg = 4326,
+  nocache = getOption("fwa.nocache", FALSE)
+) {
   chk_whole_number(epsg)
   chk_gt(epsg)
   chk_flag(nocache)

--- a/R/watershed-at-measure.R
+++ b/R/watershed-at-measure.R
@@ -30,13 +30,15 @@
 #' @export
 #' @examples
 #' fwa_watershed_at_measure(356308001, downstream_route_measure = 10000)
-fwa_watershed_at_measure <- function(blue_line_key,
-                                     downstream_route_measure = 0,
-                                     bbox = NULL,
-                                     properties = NULL,
-                                     transform = NULL,
-                                     epsg = 4326,
-                                     nocache = getOption("fwa.nocache", FALSE)) {
+fwa_watershed_at_measure <- function(
+  blue_line_key,
+  downstream_route_measure = 0,
+  bbox = NULL,
+  properties = NULL,
+  transform = NULL,
+  epsg = 4326,
+  nocache = getOption("fwa.nocache", FALSE)
+) {
   chk_whole_number(blue_line_key)
   chk_gt(blue_line_key)
   chk_number(downstream_route_measure)

--- a/R/watershed-hex.R
+++ b/R/watershed-hex.R
@@ -10,14 +10,16 @@
 #' \dontrun{
 #' fwa_watershed_hex(356308001, downstream_route_measure = 10000)
 #' }
-fwa_watershed_hex <- function(blue_line_key,
-                              downstream_route_measure = 0,
-                              limit = 10000,
-                              bbox = NULL,
-                              properties = NULL,
-                              transform = NULL,
-                              epsg = 4326,
-                              nocache = getOption("fwa.nocache", FALSE)) {
+fwa_watershed_hex <- function(
+  blue_line_key,
+  downstream_route_measure = 0,
+  limit = 10000,
+  bbox = NULL,
+  properties = NULL,
+  transform = NULL,
+  epsg = 4326,
+  nocache = getOption("fwa.nocache", FALSE)
+) {
   chk_whole_number(blue_line_key)
   chk_gt(blue_line_key)
   chk_number(downstream_route_measure)

--- a/R/watershed-stream.R
+++ b/R/watershed-stream.R
@@ -11,13 +11,15 @@
 #' @export
 #' @examples
 #' fwa_watershed_stream(356308001, downstream_route_measure = 10000)
-fwa_watershed_stream <- function(blue_line_key,
-                                 downstream_route_measure = 0,
-                                 bbox = NULL,
-                                 properties = NULL,
-                                 transform = NULL,
-                                 epsg = 4326,
-                                 nocache = getOption("fwa.nocache", FALSE)) {
+fwa_watershed_stream <- function(
+  blue_line_key,
+  downstream_route_measure = 0,
+  bbox = NULL,
+  properties = NULL,
+  transform = NULL,
+  epsg = 4326,
+  nocache = getOption("fwa.nocache", FALSE)
+) {
   chk_whole_number(blue_line_key)
   chk_gt(blue_line_key)
   chk_number(downstream_route_measure)

--- a/air.toml
+++ b/air.toml
@@ -1,0 +1,7 @@
+[format]
+line-width = 80
+indent-width = 2
+indent-style = "space"
+line-ending = "auto"
+persistent-line-breaks = true
+default-exclude = true

--- a/tests/testthat/test-collection-properties.R
+++ b/tests/testthat/test-collection-properties.R
@@ -1,13 +1,17 @@
 test_that("fwa_collection_properties works", {
   rlang::local_options(nocache = TRUE)
 
-  properties <- fwa_collection_properties("whse_basemapping.fwa_stream_networks_sp")
+  properties <- fwa_collection_properties(
+    "whse_basemapping.fwa_stream_networks_sp"
+  )
   expect_s3_class(properties, "tbl_df")
 })
 
 test_that("fwa_collection_properties haven't changed for stream networks", {
   rlang::local_options(nocache = TRUE)
 
-  properties <- fwa_collection_properties("whse_basemapping.fwa_stream_networks_sp")
+  properties <- fwa_collection_properties(
+    "whse_basemapping.fwa_stream_networks_sp"
+  )
   expect_snapshot_data(properties, "properties")
 })

--- a/tests/testthat/test-collection.R
+++ b/tests/testthat/test-collection.R
@@ -7,7 +7,10 @@ test_that("fwa_collection works with default values", {
   expect_s3_class(collection, "tbl_df")
   expect_s3_class(collection$geometry, "sfc_MULTILINESTRING")
   expect_identical(sf::st_crs(collection)$epsg, 4326L)
-  expect_identical(colnames(sf::st_coordinates(collection)), c("X", "Y", "L1", "L2"))
+  expect_identical(
+    colnames(sf::st_coordinates(collection)),
+    c("X", "Y", "L1", "L2")
+  )
 
   expect_snapshot_data(collection, "default10")
 

--- a/tests/testthat/test-collections.R
+++ b/tests/testthat/test-collections.R
@@ -3,7 +3,10 @@ test_that("fwa_collections works", {
 
   collections <- fwa_collections()
   expect_s3_class(collections, "tbl_df")
-  expect_identical(names(collections), c("collection_id", "description", "extent", "links"))
+  expect_identical(
+    names(collections),
+    c("collection_id", "description", "extent", "links")
+  )
 })
 
 test_that("fwa_collections collection_id values haven't changed", {

--- a/tests/testthat/test-index-point.R
+++ b/tests/testthat/test-index-point.R
@@ -23,11 +23,20 @@ test_that("fwa_index_point gets multiple within limits", {
   sf <- fwa_index_point(x = x, y = y, limit = 3L)
   expect_s3_class(sf, "sf")
   expect_identical(nrow(sf), 3L)
-  expect_identical(colnames(sf), c(
-    "bc_ind", "blue_line_key", "distance_to_stream", "downstream_route_measure",
-    "gnis_name", "linear_feature_id", "localcode_ltree", "wscode_ltree",
-    "geometry"
-  ))
+  expect_identical(
+    colnames(sf),
+    c(
+      "bc_ind",
+      "blue_line_key",
+      "distance_to_stream",
+      "downstream_route_measure",
+      "gnis_name",
+      "linear_feature_id",
+      "localcode_ltree",
+      "wscode_ltree",
+      "geometry"
+    )
+  )
   expect_true(!is.unsorted(sf$distance_to_stream))
 
   expect_snapshot_data(sf, "limit3")
@@ -45,9 +54,18 @@ test_that("fwa_index_point returns none if tight tolerance", {
   expect_s3_class(sf$geometry, "sfc")
 
   skip("fwa_index_point only returns geometry column when no matches")
-  expect_identical(colnames(sf), c(
-    "bc_ind", "blue_line_key", "distance_to_stream", "downstream_route_measure",
-    "gnis_name", "linear_feature_id", "localcode_ltree", "wscode_ltree",
-    "geometry"
-  ))
+  expect_identical(
+    colnames(sf),
+    c(
+      "bc_ind",
+      "blue_line_key",
+      "distance_to_stream",
+      "downstream_route_measure",
+      "gnis_name",
+      "linear_feature_id",
+      "localcode_ltree",
+      "wscode_ltree",
+      "geometry"
+    )
+  )
 })

--- a/tests/testthat/test-locate-along-interval.R
+++ b/tests/testthat/test-locate-along-interval.R
@@ -1,12 +1,19 @@
 test_that("fwa_locate_along_interval works", {
   rlang::local_options(nocache = TRUE)
 
-  sf <- fwa_locate_along_interval(356308001, interval_length = 100, start_measure = 10000)
+  sf <- fwa_locate_along_interval(
+    356308001,
+    interval_length = 100,
+    start_measure = 10000
+  )
   expect_s3_class(sf, "sf")
   expect_s3_class(sf, "tbl_df")
   expect_s3_class(sf$geometry, "sfc_POINT")
   expect_identical(nrow(sf), 93L)
-  expect_identical(colnames(sf), c("downstream_route_measure", "index", "geometry"))
+  expect_identical(
+    colnames(sf),
+    c("downstream_route_measure", "index", "geometry")
+  )
 })
 
 test_that("fwa_locate_along_interval errors with invalid", {

--- a/tests/testthat/test-meta-collections.R
+++ b/tests/testthat/test-meta-collections.R
@@ -3,7 +3,10 @@ test_that("fwa_meta_collections works", {
 
   collections <- fwa_meta_collections()
   expect_s3_class(collections, "tbl_df")
-  expect_identical(names(collections), c("collection_id", "description", "extent", "links"))
+  expect_identical(
+    names(collections),
+    c("collection_id", "description", "extent", "links")
+  )
 })
 
 test_that("fwa_meta_collections collection_id values haven't changed", {

--- a/tests/testthat/test-query-collection.R
+++ b/tests/testthat/test-query-collection.R
@@ -3,9 +3,7 @@ test_that("collection works with default values ", {
 
   collection_id <- "whse_basemapping.fwa_named_streams"
 
-  x <- fwa_query_collection(collection_id,
-    limit = 10
-  )
+  x <- fwa_query_collection(collection_id, limit = 10)
   expect_s3_class(x, "sf")
   expect_s3_class(x, "tbl_df")
   expect_s3_class(x$geometry, "sfc_MULTILINESTRING")
@@ -21,26 +19,41 @@ test_that("collection filter works", {
 
   filter <- list(gnis_name_1 = "Trout Lake")
 
-  x <- fwa_query_collection(collection_id,
-    filter = filter
-  )
+  x <- fwa_query_collection(collection_id, filter = filter)
   expect_s3_class(x, "sf")
   expect_true(all(x$gnis_name_1 == "Trout Lake"))
 
   colnames <- c(
-    "area_ha", "blue_line_key", "feature_code", "fwa_watershed_code",
-    "gnis_id_1", "gnis_id_2",
-    "gnis_id_3", "gnis_name_1", "gnis_name_2",
-    "gnis_name_3", "left_right_tributary", "local_watershed_code",
-    "localcode_ltree", "waterbody_key", "waterbody_key_50k",
+    "area_ha",
+    "blue_line_key",
+    "feature_code",
+    "fwa_watershed_code",
+    "gnis_id_1",
+    "gnis_id_2",
+    "gnis_id_3",
+    "gnis_name_1",
+    "gnis_name_2",
+    "gnis_name_3",
+    "left_right_tributary",
+    "local_watershed_code",
+    "localcode_ltree",
+    "waterbody_key",
+    "waterbody_key_50k",
     "waterbody_key_group_code_50k",
-    "waterbody_poly_id", "waterbody_type", "watershed_code_50k",
-    "watershed_group_code", "watershed_group_code_50k",
-    "watershed_group_id", "watershed_key", "wscode_ltree", "geometry"
+    "waterbody_poly_id",
+    "waterbody_type",
+    "watershed_code_50k",
+    "watershed_group_code",
+    "watershed_group_code_50k",
+    "watershed_group_id",
+    "watershed_key",
+    "wscode_ltree",
+    "geometry"
   )
 
   expect_identical(
-    colnames(x), colnames
+    colnames(x),
+    colnames
   )
   expect_snapshot_data(x[setdiff(colnames, "geometry")], "trout_lake")
 })
@@ -53,14 +66,9 @@ test_that("collection sortby works", {
 
   sortby <- c("blue_line_key")
 
-  x <- fwa_query_collection(collection_id,
-    limit = 1,
-    sortby = sortby
-  )
+  x <- fwa_query_collection(collection_id, limit = 1, sortby = sortby)
 
-  x2 <- fwa_query_collection(collection_id,
-    limit = 1
-  )
+  x2 <- fwa_query_collection(collection_id, limit = 1)
   expect_true(x$blue_line_key < x2$blue_line_key)
 })
 
@@ -72,14 +80,8 @@ test_that("collection sortby descending works", {
   sortby <- c("+blue_line_key")
   sortby_desc <- c("-blue_line_key")
 
-  x <- fwa_query_collection(collection_id,
-    limit = 1,
-    sortby = sortby_desc
-  )
-  x2 <- fwa_query_collection(collection_id,
-    limit = 1,
-    sortby = sortby
-  )
+  x <- fwa_query_collection(collection_id, limit = 1, sortby = sortby_desc)
+  x2 <- fwa_query_collection(collection_id, limit = 1, sortby = sortby)
   expect_true(x$blue_line_key > x2$blue_line_key)
 })
 
@@ -91,20 +93,36 @@ test_that("collection bounding box gets everything intersecting bounding box", {
 
   bbox <- c(-117.46, 50.6, -117.4601, 50.6001)
 
-  x <- fwa_query_collection(collection_id,
-    bbox = bbox
-  )
+  x <- fwa_query_collection(collection_id, bbox = bbox)
   expect_identical(x$gnis_name_1, "Trout Lake")
   expect_identical(
     sort(colnames(x)),
     c(
-      "area_ha", "blue_line_key", "feature_code", "fwa_watershed_code",
-      "geometry", "gnis_id_1", "gnis_id_2", "gnis_id_3", "gnis_name_1", "gnis_name_2",
-      "gnis_name_3", "left_right_tributary", "local_watershed_code",
-      "localcode_ltree", "waterbody_key", "waterbody_key_50k", "waterbody_key_group_code_50k",
-      "waterbody_poly_id", "waterbody_type", "watershed_code_50k",
-      "watershed_group_code", "watershed_group_code_50k", "watershed_group_id",
-      "watershed_key", "wscode_ltree"
+      "area_ha",
+      "blue_line_key",
+      "feature_code",
+      "fwa_watershed_code",
+      "geometry",
+      "gnis_id_1",
+      "gnis_id_2",
+      "gnis_id_3",
+      "gnis_name_1",
+      "gnis_name_2",
+      "gnis_name_3",
+      "left_right_tributary",
+      "local_watershed_code",
+      "localcode_ltree",
+      "waterbody_key",
+      "waterbody_key_50k",
+      "waterbody_key_group_code_50k",
+      "waterbody_poly_id",
+      "waterbody_type",
+      "watershed_code_50k",
+      "watershed_group_code",
+      "watershed_group_code_50k",
+      "watershed_group_id",
+      "watershed_key",
+      "wscode_ltree"
     )
   )
 })
@@ -117,10 +135,7 @@ test_that("collection properties works", {
 
   properties <- c("blue_line_key", "gnis_name")
 
-  x <- fwa_query_collection(collection_id,
-    limit = 1,
-    properties = properties
-  )
+  x <- fwa_query_collection(collection_id, limit = 1, properties = properties)
   expect_identical(colnames(x), c(properties, "geometry"))
 })
 
@@ -132,14 +147,18 @@ test_that("collection transform works", {
 
   filter <- list(gnis_name_1 = "Kootenay Lake")
 
-  x <- fwa_query_collection(collection_id,
+  x <- fwa_query_collection(
+    collection_id,
     filter = filter,
     transform = c("ST_Simplify", 50000)
   )
 
   expect_s3_class(x, "sf")
   expect_identical(nrow(x), 1L)
-  expect_identical(nrow(sf::st_coordinates(sf::st_cast(x$geometry, "POINT"))), 4L)
+  expect_identical(
+    nrow(sf::st_coordinates(sf::st_cast(x$geometry, "POINT"))),
+    4L
+  )
 })
 
 test_that("collection transform to get bbox works", {
@@ -150,14 +169,18 @@ test_that("collection transform to get bbox works", {
   transform <- "collect|envelope"
   properties <- "geometry"
 
-  x <- fwa_query_collection(collection_id,
+  x <- fwa_query_collection(
+    collection_id,
     transform = transform,
     properties = properties
   )
 
   expect_s3_class(x, "sf")
   expect_identical(nrow(x), 1L)
-  expect_identical(nrow(sf::st_coordinates(sf::st_cast(x$geometry, "POINT"))), 5L)
+  expect_identical(
+    nrow(sf::st_coordinates(sf::st_cast(x$geometry, "POINT"))),
+    5L
+  )
 })
 
 # groupby
@@ -168,10 +191,7 @@ test_that("collection groupby works", {
 
   groupby <- "gnis_name"
 
-  x <- fwa_query_collection(collection_id,
-    limit = 10,
-    groupby = groupby
-  )
+  x <- fwa_query_collection(collection_id, limit = 10, groupby = groupby)
 
   expect_s3_class(x, "sf")
   # without groupby there are duplicate gnis_names
@@ -190,10 +210,7 @@ test_that("collection bounding box and filter work together", {
   bbox <- c(-117.46, 50.6, -117.4601, 50.6001)
   filter <- list(gnis_name_1 = "kootenay lake")
 
-  x <- fwa_query_collection(collection_id,
-    filter = filter,
-    bbox = bbox
-  )
+  x <- fwa_query_collection(collection_id, filter = filter, bbox = bbox)
   expect_s3_class(x, "sf")
   expect_identical(nrow(x), 0L)
   # not sure why this is happening - is it an issue?
@@ -219,9 +236,7 @@ test_that("collection informative error invalid transform", {
   collection_id <- "whse_basemapping.fwa_lakes_poly"
 
   expect_chk_error(
-    fwa_query_collection(collection_id,
-      transform = "not_a_transform"
-    ),
+    fwa_query_collection(collection_id, transform = "not_a_transform"),
     "API request failed \\[400\\]: Invalid value for parameter transform: not_a_transform"
   )
 })
@@ -232,9 +247,7 @@ test_that("collection informative error invalid bbox", {
   collection_id <- "whse_basemapping.fwa_lakes_poly"
 
   expect_chk_error(
-    fwa_query_collection(collection_id,
-      bbox = 1
-    ),
+    fwa_query_collection(collection_id, bbox = 1),
     "API request failed \\[400\\]: Invalid value for parameter bbox: 1"
   )
 })
@@ -244,9 +257,7 @@ test_that("collection informative error invalid bbox", {
 
   collection_id <- "whse_basemapping.fwa_lakes_poly"
 
-  expect_chk_error(fwa_query_collection(collection_id,
-    filter = c(1)
-  ))
+  expect_chk_error(fwa_query_collection(collection_id, filter = c(1)))
 })
 
 test_that("collection offset works", {
@@ -254,14 +265,9 @@ test_that("collection offset works", {
 
   collection_id <- "whse_basemapping.fwa_named_streams"
 
-  x <- fwa_query_collection(collection_id,
-    limit = 2
-  )
+  x <- fwa_query_collection(collection_id, limit = 2)
   expect_identical(x$named_streams_id, c(23361, 23362))
-  x2 <- fwa_query_collection(collection_id,
-    offset = 1,
-    limit = 1
-  )
+  x2 <- fwa_query_collection(collection_id, offset = 1, limit = 1)
   expect_identical(
     x2$named_streams_id,
     x$named_streams_id[2]
@@ -274,12 +280,14 @@ test_that("collection offset works with higher numbers", {
   collection_id <- "whse_basemapping.fwa_named_streams"
 
   sortby <- "named_streams_id"
-  x <- fwa_query_collection(collection_id,
+  x <- fwa_query_collection(
+    collection_id,
     offset = 997,
     limit = 2,
     sortby = sortby
   )
-  x2 <- fwa_query_collection(collection_id,
+  x2 <- fwa_query_collection(
+    collection_id,
     offset = 998,
     limit = 1,
     sortby = sortby
@@ -295,12 +303,14 @@ test_that("collection offset works with really big number", {
   collection_id <- "whse_basemapping.fwa_named_streams"
 
   sortby <- "named_streams_id"
-  x <- fwa_query_collection(collection_id,
+  x <- fwa_query_collection(
+    collection_id,
     offset = 9999,
     limit = 2,
     sortby = sortby
   )
-  x2 <- fwa_query_collection(collection_id,
+  x2 <- fwa_query_collection(
+    collection_id,
     offset = 10000,
     limit = 1,
     sortby = sortby
@@ -320,12 +330,14 @@ test_that("collection offset works with offset more than limit", {
   collection_id <- "whse_basemapping.fwa_named_streams"
 
   sortby <- "named_streams_id"
-  x <- fwa_query_collection(collection_id,
+  x <- fwa_query_collection(
+    collection_id,
     offset = 10000,
     limit = 2,
     sortby = sortby
   )
-  x2 <- fwa_query_collection(collection_id,
+  x2 <- fwa_query_collection(
+    collection_id,
     offset = 10001,
     limit = 1,
     sortby = sortby
@@ -344,9 +356,7 @@ test_that("collection offset works at 99,999", {
 
   collection_id <- "whse_basemapping.fwa_named_streams"
 
-  expect_silent(fwa_query_collection(collection_id,
-    offset = 99999, limit = 1
-  ))
+  expect_silent(fwa_query_collection(collection_id, offset = 99999, limit = 1))
 })
 
 test_that("collection offset works at 100,000", {
@@ -354,7 +364,5 @@ test_that("collection offset works at 100,000", {
 
   collection_id <- "whse_basemapping.fwa_named_streams"
 
-  expect_silent(fwa_query_collection(collection_id,
-    offset = 100000, limit = 1
-  ))
+  expect_silent(fwa_query_collection(collection_id, offset = 100000, limit = 1))
 })

--- a/tests/testthat/test-watershed-at-measure.R
+++ b/tests/testthat/test-watershed-at-measure.R
@@ -1,7 +1,8 @@
 test_that("fwa_watershed_at_measure works", {
   rlang::local_options(nocache = TRUE)
 
-  sf <- fwa_watershed_at_measure(356308001,
+  sf <- fwa_watershed_at_measure(
+    356308001,
     downstream_route_measure = 10000,
     properties = "area_ha"
   )

--- a/tests/testthat/test-watershed-hex.R
+++ b/tests/testthat/test-watershed-hex.R
@@ -1,7 +1,11 @@
 test_that("multiplication works", {
   rlang::local_options(nocache = TRUE)
 
-  sf <- fwa_watershed_hex(356308001, downstream_route_measure = 10000, limit = 1000)
+  sf <- fwa_watershed_hex(
+    356308001,
+    downstream_route_measure = 10000,
+    limit = 1000
+  )
   expect_s3_class(sf, "sf")
   expect_s3_class(sf$geometry, "sfc_MULTIPOLYGON")
   expect_identical(nrow(sf), 996L)

--- a/tests/testthat/test-watershed-stream.R
+++ b/tests/testthat/test-watershed-stream.R
@@ -19,5 +19,8 @@ test_that("creek with more than one multistring!", {
   expect_s3_class(sf$geometry, "sfc_MULTILINESTRING")
   expect_identical(nrow(sf), 5L)
   expect_identical(colnames(sf), c("linear_feature_id", "geometry"))
-  expect_identical(sf$linear_feature_id, c(706816010L, 706815933L, 706815750L, 706816149L, 706816140L))
+  expect_identical(
+    sf$linear_feature_id,
+    c(706816010L, 706815933L, 706815750L, 706816149L, 706816140L)
+  )
 })


### PR DESCRIPTION
Closes #90

Adds air formatting following the org standard (as in `chk`):

- `air.toml` with the standard `[format]` settings
- `.vscode/` settings recommending and enabling format-on-save with Posit air
- `.Rbuildignore` entries for `air.toml` and `.vscode`
- All R source formatted with `air format .` (air 0.9.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)